### PR TITLE
Sentinel-2 data

### DIFF
--- a/docs/tutorials/sentinel-2-imagery.ipynb
+++ b/docs/tutorials/sentinel-2-imagery.ipynb
@@ -1,0 +1,459 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "hired-density",
+   "metadata": {},
+   "source": [
+    "# Search for Sentinel-2 data from the Copernicus Open Access Hub"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a78798b-5c0d-4dac-9aeb-9881906b2c2e",
+   "metadata": {},
+   "source": [
+    "In this notebook we query the [Copernicus Open Access Hub API](https://scihub.copernicus.eu) for the Sentinel-2 scenes intersecting a glacier geometry, as extracted from the [Randolph Glacier Inventory (RGI)](http://www.glims.org/RGI/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "0d39ef78-e6a1-4f5b-8b5d-5d4f11057534",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "import geojson\n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "import sentinelsat\n",
+    "import shapely.geometry\n",
+    "\n",
+    "from dhdt.auxilary.handler_randolph import download_rgi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "regulated-commons",
+   "metadata": {},
+   "source": [
+    "## Define the area-of-interest (AOI) using the RGI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "750f1930-91f4-43ee-b782-98914f0a2f61",
+   "metadata": {},
+   "source": [
+    "We define the coordinates of a point on the glacier of interest and download the corresponding RGI files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "53878a89-8462-4598-8209-21b30a7b82c8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Brintnell-Bologna Icefield (Northwest Territories)\n",
+    "lat = 62.09862204\n",
+    "lon = -127.9693738\n",
+    "\n",
+    "# download RGI files, get the path to the shapefiles\n",
+    "rgi_paths = download_rgi(\n",
+    "    aoi=(lat, lon), \n",
+    "    rgi_dir=\"./data/RGI\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2502e0ab-1f6e-431d-8de5-fe0cb4ad5e88",
+   "metadata": {},
+   "source": [
+    "We load the RGI region as a `GeoDataFrame` and identify the glacier by intersecting it with the defined point:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d5c6bb2a-6211-401d-8f2e-b1f69de8b250",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "point = shapely.geometry.Point(lon, lat)\n",
+    "glaciers = pd.concat([gpd.read_file(p) for p in rgi_paths])\n",
+    "mask = glaciers.intersects(point)\n",
+    "glacier = glaciers[mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "58ec34c5-fe0b-4775-af3f-50a00603d5f7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAa4AAAGFCAYAAAClnhdvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy88F64QAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA870lEQVR4nO3dd5hU1f0G8Hf67M72vixb2KUsvRfp0uwNFVFRUdFEgzFGzc+YmGbURKOxJCoqithiLCgqikAEQXpx6XV7Z3uZnZ12f38Qjbh1du/MuffO+3keHmV25t4vCzvv3HPP+R6dJEkSiIiIVEIvugAiIiJfMLiIiEhVGFxERKQqDC4iIlIVBhcREakKg4uIiFSFwUVERKrC4CIiIlVhcBERkaowuIiISFUYXEREpCoMLiIiUhUGFxERqQqDi4iIVIXBRUREqsLgIiIiVWFwERGRqjC4iIhIVRhcRESkKgwuIiJSFQYXERGpCoOLiIhUhcFFRESqwuAiIiJVYXAREZGqGEUXoEW1zU68siUXu/Jr4fJ4MSAhDNdNTMeo1Kg2z61uaoXHKyEhwhr4QomIVEgnSZIkuggtqWhw4MoXtqK4tuWsx3U64JHLh+O6iWnfP7Zs0yk8vvYYvJKEX52XjTtmZgW6XCIi1WFwyajO7sSNr+7E/uL6dr+u0wF3zszClP5xWHOgDG9uL/z+a3odsPYX0zEgMTxQ5RIRqRKDyweSJMHtlWDU6wAAbq+EWrsTpXUObM+txqtb8lDZ2Nrj4y+enIE/XDpUrnKJiDSJweUDr1dC5oNrAJy5epL7OxcdasLO38yBycA5M0REHeE7pA90uv/9vz/ivtbuwtZT1fIfmIhIQxhcCrP2ULnoErr06f5SHCtvFF0GEQUpBpcPvAEYVF1zoAxOt9f/J+qh5VvysPTtfVj40jYcKWsQXQ4RBSEGlw/cXv8HSp3dhfVHKr7/vcvjxeqcUjy65ghe2ZyLOrvT7zV05F87C/Hwp4cBnBnWvP6VHcivahZWDxEFJ07O8IHd6caQ3631+3mGJEdg1c8mo8XpwS0rdmFvYd33X0uJCsGqn01GQnhgFywfKWvApf/YApfn7H8uQ/tE4KOfTeGEEiIKGL7b+CBQQ3iHyxow56lNmPPUprNCCwBK6lrwt7XHOnztrvwaVDX1fEp+e6qbWnHXO/vahBYAHCptwB9WH4I3EOOoRETgFZdPKhocmPjoBtFlwGzUY9eDcxAZajrr8SNlDbj4uS0wG/SYMyQRo1KjkBIVgvhwM8IsJoSaDQizGGGzGGE2dv2ZxeHy4KN9JXhq3fEu16dNyIjB3XMGYHJWLHQ/nH5JRCQzBpcPCqqbMeOJjaLLAAD8+fJhWDQp/fvfS5KEa1/eju25Nd16fVyYGYOTI3DJyD6YPzoFxh8M9dW3uPD8xpP4184i1Le4fKorOykc98wdiPOGJvn0OiKi7uJQoQ+aWt2iS/jep/tLz/r91lPV3Q4tAKhqcmLziSr86v39uHnFLrQ4PQCA4lo7LnluC5ZtyvU5tADgaHkjfvLGHjyx9qjPryUi6g52h/dBk0M5wbUzrwbVTa2IDbMAAN7aUdDjY20+UYWrl23FjIHxeH9PMSoaen+PzGI0QJIkDhsSkewYXD5oUFBweSXgk5xSLJ7SD6cbW7HucEXXL+rEwZIGHCzp/bosq0mPZxeOxjwOFRKRn3Co0Ac1zfLO1uutN3cUwuuVsGJrXrsz/kR4/KqRDC0i8itecfmgqknc4t/2nKxswvWv7MCeglrRpXxvELdlISI/4xWXDyobHKJLaGNbbjWcHuW0iPr1h/sV3bKKiNSPweWDcgUGl9LsLazDo2uOiC6DiDSMQ4U+KKtncHXHiq35AIDfXjT4rPVhRERy4LuKD4prW0SXoBortuZjycrdaHT4vhaMiKgzDK5uanC4UNOsrMkZSrfx2Glc+cJWlNYx8IlIPgyubjpZ2SS6BFU6XtGEBcu2oajGLroUItIIBlc3HS3jjr89VVzbgmuWbUNBNffuIqLeC7rgWrWvGC9sPAWPj9twHCip809BQaK03oEFy7bh1GleuRJR7wRNcHm9Ep5adxz3vJuDv35xFHe9sxcNPkwc2J2vnEW+alXR0Iobl+9EBZcVEFEvBMW2Jo0OF+55Nwfrj5zdzy/GZsaiSem4bkIakiI73lG4tK4Fk//yH3+XGTSy4m14a8mkTr/nREQd0XxwebwSFr2yA9tyqzt8jsmgw3UT0vCr87Nhs7Rd2vbK5lz8+TMuqpVTakwI3rp1EtJiQ0WXQkQqo/mhws8OlHUaWgDg8kh4fVsBbnx1Jxwuz1lfkyQJ7+8p9meJQamopgVXvbgVJyo46YWIfKP54PIldPYU1OK+93LO6rX37q4iHC3nm6s/VDa2YsGybcgpqhNdChGpiKaHClvdHoz4w5do9bHpa784G84dlIDyhhZ8frAc2v0OKYPVpMfT14zG+cO4HQoRdU3TwbW3sBbzn98qugzqBp0O+M2Fg3Hr1H7cNZmIOqXpocLDpb3f0ZcCQ5KAP392BA99fBBuBW3TQkTKo+ngyqtipwa1eXN7IW59nc15iahjmg6uQvbHU6VNx0/j6he3sTkvEbVL08HFDg3qdbS8EfOf34p8XjUT0Y9oOrjKufGjqpU3OHDdy9vZWZ6IzqLZ4PJ4JVRz/yzVK613YOFL21Fcy/AiojM0G1w1zU6fO8CTMpXUteCaZdu5LQoRAdBwcJ1ubBVdAsmopK4FV7+4jS2iiEi7wVXewBlpWvNdi6iDJfWiSyEigTQbXCW1DC4tqrW7cO1L27E7v0Z0KUQkiGaD69Rp3g/RqsZWN25YvpOdUYiClGaDi8NJ2tbi8uBnb+9lhw2iIKTJ4GpwuJBTXCe6DPKzvKpm/PrDA6LLIKIA02RwbT1ZBZeHU+GDwaf7y7DmQJnoMogogDS7rcnR8gas2luC1TmlKGMHDU2LCzNj3T0zEG0ziy6FiAJAs8H1Ha9Xwr6iOnz230/m5exfqElXjumLJxeMFF0GEQWA5oPrh7xeCXsLa/HZgTMhVtHARcpa8uKiMTh/WLLoMojIz4IquH7I65Wwu6AWq/YV45OcMjS1ukWXRL1kMerx9m2TMDY9WnQpRORHQRtcP2R3uvH5gXK8u7sIO/O4sFXNokNN+OCOyciMDxNdChH5CYPrR/KqmvH+niK8v6eYQ4kqlRYTii9+MQ2hZqPoUojIDxhcHXB7vPhkfyme/PI4itk+SnWeu3Y0LhnZR3QZROQHDK4utLo9eGdHIVZuK0Aud+NVjZmD4rHi5gmiyyAiP9BUcK0/XAGnx4vzhyZBr9fJemxJkrC3sA7v7ynGpzmlaORkDsV7ZuEoXDYqRXQZRCQzTQXXE2uP4p9fnUJ2UjjumTsQ84YkQqeTN8AAwOHyYOOx0/h0fyn+c7QSdqdH9nNQ70VYjVh7z3QkR4aILoWIZKSp4Lr/vRy8t6f4+98PS4nAPXMGYlZ2gl8CDDgzlLj621I8uOoA20wp0PlDk/DiDWNFl0FEMtJUr8LTTWfPAjxY0oBbX9+Ny5/fik3HT8MfGW0xGnD1uFRcPIITAZToi0Pl2HKiSnQZRCQjTQVXZQfT13OK6nDTqztx1Yvb8M3JKr8EWLiVU6+V6g+fHILL4xVdBhHJRFPB9eMrrh/bU1CL61/ZgWte2o5dMu+gy0a+ynWysgmvb80XXQYRyUQzweX1SqhpdnbruTvzanD1i9tw5QtbseZAGdwyfBovqrH3+hjkP0+tO45Tp5tEl0FEMtBMcDU63PB4fRsC3FNQizvf2osZT2zEy1/noqGHu+kW1dgZXApnd3rws7f2wuHiDFAitdPMrML8qmbM/NvGXh3DZj4z0eLmKRlIj7V1+XyHy4Olb+/D+iMVvTovBc75Q5Pwz+vHwCDzOj8iChzNBNf+4jpc+o9vZDmWTgfMGZyIW6f2w8R+MW2m0nu8EnbkVuMfX53E1lPVspyTAufGc9Lxx0uH+m2JBBH5l2amwtW39GyYrz2SBKw7XIF1hyswpX8sxqbHIDrUhMgQE/YX1+PT/WWo6mIiCCnXym0FiLCa8Mu5A2XvsEJE/qeZ4Gpo8U8Lpm9OVuObk7yq0pp/fHUSdqcHD108mFdeRCqjmckZPZ1YQcHr1W/ycP/7+1HNq2ciVdFMcNXZGVzku/f3FGPWk5vwxrZ8n2elEpEYGgqu7q3hIvqx+hYXHvr4EH7572/90lWFiOSlmeDq7uJjoo58/G0plm/J45UXkcJpJrg4y4/k8OfPjuCiZzfjq6OVvPoiUigNBRevuEgeR8sbcfOKXVj40nbsLawVXQ4R/YhmFiBPfmwDStnolvxgclYsbpqcgTmDE9lxg0gBNBFckiQh+6Ev0Orm1hXkPylRIbh1aj8smpQOs1EzgxVEqqOJ4LI73Rjyu7Wiy6AgkR4bigfOz8b5w5K4eJlIAE18bKzm/S0KoIJqO+54ay+ufnEb9hTIu68bEXVNE8HFqfAkwu6CWlz5wjY8uOoAmlv903KMiNrSRHBVN3MqPInz9o5CXPDMZuzM49UXUSBoIrjK6xlcJFZhjR3XvLQNj645ws0qifxME8FVUsfdh0k8SQJe+joXl/5jCw6W1Isuh0izNBFc+VUMLlKO4xVNuPyf3+DZDSfg9nCJBpHcNBFch8saRJdAdBa3V8JT647jyhe2Ir+qWXQ5RJqi+uCqampFHt8YSKFyiutx6T+24Ovjp0WXQqQZqg+uzSf4hkDK1uBwY/FrO/Hy17ls3EskA1UHlyRJeGdHkegyiLrklYBH1hzBL/+dw1mHRL2k6uB6eXMuduZz7Qypx6p9Jbj4uS3YX1wnuhQi1VJdr0JJkrD5RBVe2ZLH+wakWga9DnfOzMKN52QgPtwiuhwiVVFVcO0pqMUDH+zHicom0aUQySLcYsTDlw/D5aNTRJdCpBqqCa5d+TVY9MoObl1CmnT5qD743SVDEWMziy6FSPEUHVwer4SC6maszinFCxtPMbRI08wGPeYNTcT8MSmYnBUHq8kguiQiRVJUcLU4PXhrRwG2nqpGflUzimtb4GTnAQpCVpMek7PicG52AmYMiEdabKjokogUQzHBZXe6cdUL29gFg6gdaTGhmDYgDudkxaJ/QhgyYm28IqOgpZjgemrdcTy74YToMohUQacD+kSGIDPehlGpUZjSPw6j06JgMTLMSPsUEVxujxeTHvsPqpq4PQlRT1lNeozPiMHU/nEYnhKJlOgQJEVaGWakOYoIrq+Pn8aNr+4UXQaR5uh0QHyYBclRIQg1GWA26r//ZdLr4JUAjyRBkiR4vYBXkmAxGWA16hFiNsBq+u6XHiEmA0JMZz/WL86GtJhQ6HQ60X9UCiJG0QUAwJeHy0WXQKRJkgRUNraistF/oxlxYRaMTY9CUoQVVrMBoSYjrCY93F4JDpcHLU4PHG4PWpxeuDxeJEVakRYTioxYG4b3jURkiMlvtZE2KSK4vj5eJboEIuqhqqZWrD1U0aPXmgw6TB8Qj4tGJGPOkEREWBli1DXhQ4WF1XZMf+IrkSUQkQKYDDoMSgrH8JQojOgbieEpkRiUFA6TQdUtVckPhAfX2zsK8eCqAyJLICKFspkNGJcRg5mD4nHthDQuASAACgiupW/vxaf7y0SWQEQqkBoTgocuGoK5QxI5GSTICb0GlyQJO/K4LQkRda2opgW3v7EHN722CyfZaDuoCb3iOlregPOf3izq9ESkUka9DqNSozAwKRyZcTYU1thRUG3HmLRonJMVi7Hp0TDoeVWmVUKDa9mmU3js86OiTk9EGjUoMRz3nzcIswcncFhRg4QG13Uvb8fWU9WiTk9EGjcmLQr3zhuEczJjoecVmGYIC656uwvjHlkHl0d44w4i0ri+0SG4amxfXDW2L/pGs9O+2gkLrnd2FuLXH3IaPBEFjk4HTMmKwyUjk3He0CREhXLjTjUSFlxXvbAVuwtqRZyaiAhGvQ5TB8ThouHJmDckCZGh7NqhFkKCq7SuBZP/8p9An5aIqF1sPaUuQnoVbjjSs75mRET+4PJI2HC0EhuOVsJs0OP6SWn4v/Oz2alDoYQsQF53pFLEaYmIuuT0ePHaN/m44vmtXOisUAEPLofLg+25nAJPRMp2pKwBlzy3BW9sL4DXy9nPShLw4DpZ2QSn2xvo0xIR+azF5cFDHx3ENS9tw8nKRtHl0H8FPLgqGx2BPiURUa/syq/Fhc9swdPrj8Pl4Qdv0QIeXE43L7mJSH2cHi+eXn8CV76wFbmnee9LpIAHV4iZs3SISL32F9fjome34O0dhRC8K1TQCnhwRYVwfQQRqVuLy4MHVx3AbSv3oLqpVXQ5QSfgwRVjY4sVItKG9UcqcN7Tm7HxGJf4BFLAgys2jMFFRNpR1dSKm1fswvMbT3LoMEACHlyhZiNCuBqdiDREkoDHvziGe/+dA4fLI7oczRPSOYPDhUSkRR/uK8F1L2/H6Ube9/InBhcRkYz2Ftbh6he3orSuRXQpmiUkuCJChPT2JSIKiPxqO655aRuKauyiS9EkIcEVZmFwEZG2FdW0YOFL21FYzfCSm5DgCudeN0QUBErqWnDty9tR0cBWd3ISElyh7J5BREGipK4FS9/ey6nyMhISXJwOT0TBZFd+LXYX1IouQzOEBBd3FSWiYPP0+uPc10smDC4iogD45mQ1Xvz6lOgyNEFIcJmNQk5LRCTU39Yew7ZT3AG+t4QkiIXBRURByCsBd72zD5WcZdgrQhZU8YpLHcwGPTLjbRiQGA6zQQ+H24PyegcOlNTD6eYusEQ9UdXUirve2Ye3lkyE0cD3wp4QE1z8y1I0o16H26dn4q5ZA9rd+LPV7cGGI5V4ev1xHK/gTrBEvtqRV4NnNpzAvfMGiS5FlXSSgMUFn+4vxdK39wX6tNQNKVEhWL54HLKTIrp8rscr4dP9pXhm/QnkVjUHoDoi7TDqdVhz9zQMTAwXXYrqCLn0MfGKS7FuPCe9W6EFAAa9DpeNSsGX90zH364eibSYUD9XR6Qdbq+E3350kAuTe0BQcOl6fYxx6dF4bP5w/PaiwUiJCpGhKoqwGnHT5AyfX2c06HHV2L7YcO8MPDZ/OKJC2dKLqDt25tXgw70lostQHSHBZdD37rQXjUjGv26fhGsnpGHJtEys+tlkxIVZZKoueM0ZktirNXYmgx7XTkjDF3dPx+SsWBkrI9KuR9YcQXk9Zxn6QswVl77nV1wXDU/Gk1ePPGs2TkK4FXfPGSBHaUFtQkaMLMdJirTizVsn4oELsmHsxd81UTCoaXbirnf2wu3hTN3uEjKrUN/Fm5nFqEdUqAmRIWd+xYdbkBUfhlnZCRidFt3ua64e2xfPrD+OqianP0rWPKNeh1mDE2Q7nl6vw09nZOGczFjc/a99yOfWDkQd2pVfi7d3FuLGczJEl6IKQoLL0E5wWYx63DEzC5ePSkF6bCh0Ot8+qVtNBiyenIG/fXlcrjKDyryhiUgIt8p+3JGpUfjs59Nw+xu78c1Jdgwg6sjf1x3HZSNTEMl7xF0SMlT449wKtxjxzu2T8Is5A5ERZ/M5tL5zwzkZiLGZZagw+Pjzk57NYsTz141Fvzib385BpHa1dhf+/Nlh0WWogqB56f8LpvhwC1beOgFjOhgC9EVkiAlPXzOKLaV8NGdwAiZl+ncyRWSoCa/cNA5WE/9uiDry3p5irDtcIboMxRPUHV6P0WlRuG/eQKz/5YwO71v1xPSB8fj87mm4ZGSfdock6WxGvQ6/vnBwQM6VFR+GC4cnB+RcRGr16w/3o7qpVXQZiiakc0agFNXY8cdPDmP9EX6C6cjs7AQsXzw+YOfbeqoK1728I2DnI1Kj84cm4YVFY3p820TrND1ukxoTipduGIu5QxJFl6JY/h4ibHO+frFcME7UhS8OleOjb7kwuSOaDi7gzLTsv8wfzgXKHRiXId8wbXfo9TqMSo0K6DmJ1Og3qw5iV36N6DIUSfPBBQCxYRa8uGgMu9K3Iz488IEebhWyCoNIVexODxa/uhN7C2tFl6I4QfNOPi4jBn++fJjoMhTHZg58iDQ63AE/J5EaNTs9uGn5TuwvrhNdiqIETXABwNXj+mLOYN7v+qH29tvyp+qmVuwu4PAHUXc1trpx06s7caKiUXQpihFUwaXT6fDny4dxkfIPNDhcATuX3enGkpW7UdHAqb5Evqi1u3D9KztQyNZpAIIsuIAzDWCX3TCWC2H/62iZ/z/Ftbo92JVfg9tW7sa+wjq/n49IiyobW7Fo+Q5UNLCTvKbXcXXmm5NVuPX1XXC4AtuR+bZp/TArOxGPfX4E+4vrA3ru9jx4YTZun57V6+O0OD2obHSguLYFuaebkFvVjLz//iqqscMblP/KiOTXPyEMby2ZiMQI+XuLqkXQBhcAfHW0Ere8vguB+g5cOaYvnlwwEgBQXGvHzCc2wi34Hf2K0Sn4+zWjOn1OXlUzPskpxeHSBjQ73XB7JHi8ElxeL+rtLlQ2tqKplRMuiAIlLSYUby2ZiNQg3XU8qIMLAO5/Lwfv7Sn2+3lSokLwxS+mIdz6v87PN7+2E18dO+33c3cmJSoEW/7v3A5X6L+7qxAPfXwITjf3CiJSksQIC968dSIGJIaLLiXggv5Gz5Vj+2Jk30i/nkOnA55cMPKs0AIC37WiPSV1Lahubn8Ps8OlDfjtRwcZWkQKVNHQivnPb8VzG07A4fKILieggj64JmXG4uOlU/HBHZP9thh3ydR+7YZUdnKEX87nC53uTFf9H3O4PLjn3W/h8gT1BTmRojW2uvHkuuO45qXtKK8PnkkbQR9c3xmbHo3lN42DySBvU8uUqBDcO29Qu1/LVMD+VAnhFpja6Sjy7IYTOMZ1I0SqkFNUh4uf2xI0LaIYXD8wom8UHrl8uKzHXDKtH6ym9hf59okKgVHw1ivJkW0b3lY0OLB8S56Aaoiop6qaWrHolR04WCJ+trK/Mbh+ZMH4VLy1ZCIGJob16jj94my4YFgSZmUndPgcg16HvtFiO6X3iWo7pfb5r06ilfe1iFSn1e3FHW/tQZ29/fvWWsHgaseU/nFY8/NpuGOm7+ub+kRa8c5tk/DVfTPxwqKxSI/tfDiwq6/7W1JE2+DceFzsTEci6rmimhbc/a9v4dHw4kkGVweMBj1+dd4gzPNhL68QkwFvLJmIc7K6P1swM15scMWGnd3+qsHhQgHbyhCp2qbjp/HM+uOiy/AbBlcndDodHr58WLc2PtTpgD9dNhRZ8b4NMQ4WPLPwxzMKA9ECioj879n/nNTsZA1ujNSFxAgr1tw9Dav2FiOnuB5VTa1odXshSRKsJgNCzQZkxNpw4fBkjOzBBomiN1VM+lHbmKPlDYIqISK5PfDBfqy5exosxsDuAuFvDK5uiAwxYfGUfn45dv/4MIRbjGgU0DLJZNBhYmbMWY/lnm4OeB1E5B+nTjfjj58cxqNXyDtbWjQOFQqm1+swUVAHjXHpMW26eZTWtQiphYj84+0dhXh3V6HoMmTF4FKA84clCTlvQkTbTiELJ6QKqISI/OmPnxwWXYKsGFwKcOHwJIRbAz9qO31AfJvHzh2UwF2iiTRGa+syGVwKEGo2YsG4wF7pLJqUhivH9m3zuE6nw7IbxuKRK4Zh0aQ0DArCztNEWuPV2CYgQb+tiVIU1dhx7t8Csz/XtAFxWH7TeJiN3fvcUlDdjDve3IvDZZxxSKRWeY9d2OH2RWrDKy6FSI0JxZ3n9vfrOSJDTHj8yhFYecuEbocWcKa7x8s3jUPcjxYrE5F6iN60Vk4MLgX5xewBuLqd4Ts5DEuJwOd3T8OC8ak9+tSVEhWC310y1A+VEVEgNGtol3IGl4Lo9Tr89coRmD86RdbjTu0fh/d+Mhl9utEBpDMXDU9GXJh/9iwjIv/6zaqD8GrkqovBpTB6vQ6Pzh+O7CR5JkXYzAY8ftUIhJh7v3LeoNfhAkFT94modz47UIbffHRAEzuaM7gUyGoyYNkNY5Ec2XbLEV/dO29Qr6+0fujC4cmyHYuIAuudnUW4YfkOVDe1ii6lVxhcCpUea8PHS6dgfEZ0j48Rajbg+klpMlYFTOgXw+FCIhXbkVeDS//xDY6oeJYwp8MrnMPlwc2v7cK23GqfXzs7OwHLF4+Xvabff3wQr28rkP24HYmxmZEUYUWI2YAQkwFWkwFhFgNibBbUtTiRU1SHU+yxSOSTMIsRD18+FBcMS+5wl3alYnCpQHGtHbP+tglOj29j03fPHoB75g6UvZ4TFY2Y+/evZT/u/NEpWDwlA6FmAyxGAywmPawmA8Itxk5nQkqShGc2nMDT60/IXhMFh1ibGWmxoYgONcNmMSLMYoDNbESoxQiTXocWl+fML6cHpfUO5BTVob7FJbpsWUSGmLBkaj8snpLRpnepUjG4VGLp23vx6f4yn17zxFUjcLWfOnLcsHwHNp+o6tUxDHodxqZHY3Z2AmYPTkD/hN5NSFmdU4r738vRXHsbkodOB2TFh2FYnwj0iwtDRlwo+sXZkB5ra7MvXVe8Xgl51c34trAO+4pq8W1RHY6UNap61+GoUBPunTcI145PhdHQ8V0kSZKQX23H/uI6FNXYYXd6cMM56UiOlO9eelcYXCrx5aFy3P7GHp9e85f5w7Fwgrz3uL7z1bFK3Pzarh6/fmx6NP6+YBTSYkNlrArYV1iL21buQZXKbz5Tzxn1OiRFWpEUYUVyVAiGJEdgZGokhqdE+vWKwu50Y39xPfYW1mJvQR2+LapFVZPTb+fzlzCLERP7xWBgUji8koTE8DPD9PUtLhwubcCOvGpUNPzv58ts1GPfQ3NhswSu3yqDSyUcLg/GPLwOdqen269ZPDkDf7jUP4uGJUnCsq9z8eHeYuRX2bscxowLM2NcegymDIjD1P5xyIgN9Vv7mZK6Fix5fbeqbz6Tb2JtZpybfaZB9LQBcd16E211e5BX1Yw6uwv1LWd+NbT87//1Oh1sFgNsFiNsZiOiQk3IiLUhI677V2j1LS4U1dhRXGtHUU0LCmvsKKq1o6jGjqLaFtmmpodbjBiYFI5BSeFIjwmFR5LQ5HAjp7gO205Vw58XgtMHxmPlLRP8d4J2MLhU5NYVu7DhaGW3n2826HHL1H74xZwBfr/56nB5UN/igtPthdsrwe0589+IEBPiwyw+tZiSQ3OrG3f/61usP1IR0PNS4IRbjVg4PhXnD0vCqNRoGPSdfxBqdLiwt7AOu/JqsDO/BjlFdT0eVo6xmdEvzoaMWBsy423oF2fDwMQwpMfaYOpkmO2HvF4JFY0O5FfZUVDdDLvTg3CrEeFWI/Q6HfYU1mLZptxOjzEpMwb3zRuEsenRHX4QLKy24+XNuXh3d5Hsa7jiwy1YecsEDE6OkPW4XWFwqcirW/Lwp09921fHqNfhyMPnd/uHSUs8Xgk/fXMP1h1meGlJYoQFt07th2snpHU69Gd3urHp2GnsyKvBrvwaHClr8OuVBwDodWfezJMirEiIsCIx4of/f2b4MjHCgsgQU5cjDnV2J0b9aV27Xwu3GvHHS4fiitEp3R65yKtqxv3v5WB3Qa3Pf64257cY8dDFQ3Dl2L5dfmDwBwaXihyvaMQ8H2fz9U8Iw/pfzvBTRcrncHnwbVEd9hfXYW9BHb4+cdqn4VZSjsx4G346PQuXje4Di7H9EQRJkrArvxbv7S7CmgNlaFbo37XFqEdihBUhJgP0eh30ujOTlfQ6HQx6HSRJQmVjK4pr2+5IPiEjBs9cO6pHkyE8XgmvbsnDX7442uOJJLOyE/DIFcMCOhnjxxhcKiJJEiY+ugGVjd2feDBvSCJeunGcH6tSl/oWFx7+9DDe31MsuhTqppGpUbhjRhbmDUmEvoNP9/UtLvx7VxHe2lGA/Gp7gCsMnJGpUXh7ycReT4TYerIKd7y116cp/bE2M35/6VBcMiJZ+PYogd92l3pMp9Nhav84fLivpNuv6Rdv82NF6hMZYsITV42AxythlQ/fRwq8GQPj8dMZWZiUGdPhG+Wp001Y8U0+PthbrPkr6cx4G15bPF6W2XuT+8fh3Z9MwsXPbulyuxOzUY8bJqVj6bn9EW1TxtZGDC6VmT4w3qfgSouRd7q5Fuh0Ojxx1Qj0i7Ph1W/yUGfXxkJSEdJiQjEuPRqDkyOg1+vgdHtR1+JETZMTFY2tOFXZhJK6tsNdnZkxMB6/On8QhvaJbPfrkiRh84kqLN+Sh03HT8vxx1C8lKgQvHHrRMTIGBzZSRG4c2YWXt6chxbX2aH/3eSTC4cn45KRyUgI733fVDlxqFBl6ltcGPfndXB5uvfXtvKWCZg+MN7PVamXy+PFgZJ6bDtVjc/2l3GX526akBGDR64YhgGJXS8ab2p143hFI46VN+JoWQOOlDVid0FNm4kSyZFW/P6SIThvaFK7V1gOlwervy3FK1tycbyiSa4/iuJdPqoP/njpMESG+mcNmiRJaHV70dzqhsPtRazNrPgWUAwuFbpt5e5uz5T7z70zkBkf5ueKtEGSJLyyOQ+PrDkiuhRFy04Kx2c/n9ar2WQ5RXX4vw/242h5I4x6HW6d2g8/nz2g3WGwmmYn3txegJXb8lW5oNdXKVEhGJYSgdToUJyTFYvZgxNFl6Q4DC4Vcrg8eHN7AV7cdKrLH+SjD5+v+E9PSvPbjw7gze2FostQrItHJOMf143p9XHcHi+2nqrG0D4RiO1gx4E1B8rw4KoDmh/OTYkKwUUjknHR8GSM6BspfPKD0jG4VMzudOOWFbuwPbem3a/Hh1uw6zdzAlyV+jndXtz6+q5e92LUqjCLEZvun9lh2MihweHCHz4+5NP9XLVJjrTiwuHJuGhEMkanRjGsfMDgUrkGhwuLXtmB/cX1bb42Oi0Kq+6cIqAq9bM73ViwbBsOlvCeV3uunZCKR68Y7pc329K6FixYtq3dNUxqlxEbipmDEnDJyGSMTo3ucHo/dY7BpQEOlwe/+/ggPtpXCr0eiLVZUNXUiouGJ+Opa0aJLk+1TlY2Ye7fN4E/Ie27a1Z//HLuQFnDq77FhQUvbsOxikbZjimKUa/DxMwYTMiIxai0KIxIiVTMdHK1Y3BpiNcrff8JrrLBgb2FdTh/WJLgqtRNju1btOzyUX3wx8uG+bwtSHvq7E7cvGIX9hXW9b4wQawmPc4bmoS5QxIxfWA8IlSyv5XaMLiIOvHPr07iibXHRJehaH0irXj9lgndmhrfkbL6Fty4fCdOVKpzmntKVAhumpyOBeNSERXKqyp/4wJkok4M7RPYrtdqVFrvwCNrjmDFzb5vbSFJEtYeqsCfPjmE0nqHH6rzr3MyY7F4SgbmDE4U0mw2WDG4iDqRxTVw3bLx2GnYnW6Emn17Sznd1IqfvunbBqmiDUgIw9whibhsVAoGJfVu127qGQYXUSf6RIXAZNB1u1NJMNP3YJJGnM0Co17XZb880camR+OCYUmYMzgRGXHs/ykag4uoEwa9DokRVk1OzZbT1WP79mihu16vQ3KUFUU1yvz+zspOwNJZ/TEmLVp0KfQDDC6iLiSEWxhcnegXZ8MfLh3a49ePSo1WXHClRIXgj5cOxZwhbLekRMG3LS6Rj+SY6q1VJoMOzy4c3autNib0i5Gxot7R64AlU/vhy3umM7QUjFdcRF3g9OaO3TdvEIb3bX/7ke4qrlXGxo/x4RY8s3AUJmfFiS6FusDgIupCmAwb92nR1P5xuG1aZq+O0ehw4W0FNDROjQnBB3dMVty+U9Q+DhUSdSHEzO76P3be0EQsu2Fsr3vtvbWjEI2tbpmq6hmzQY9li8YxtFSEHyWJutDZbLnMOBvunjMAVpMBW09W4d3dRXC4vAGsLvCWnnumR2FvQ6u22YnnvzopU1U9938XZGMIF5qrCoOLqAsWY9uBiRibGQ9ckI35o1NgNJz5+nlDk3DtxDTcvnIPCmuUcd9GTmajHk9cNQKXjUqR5XjP/eckGhxir7ZG9I3EzZMzhNZAvuNQIVEXTIazryxibGa8c9skLBiX+n1ofSc7KQKrl07BtAHausE/KDEcq5dOkS208qua8cb2fFmO1Rs/mZ7FrUVUiMFF1AWj/n8/JtGhJry1ZGKnrX6iQs14bfF43D69dxMXlOKmc9Lx8dIpyE6Sbzjt8bVHFdGNJD02VHQJ1AMcKiTqgvG/V1xhFiPeXDIRg5O7fgM3GvR48MLBsDvdeFMBs+Z6ItxqxJNXj8S8ofJujfPVsUqsOVAu6zF7KimSEzLUiFdcRF34bqPEu2b1x9A+vq1Z+t3FQzEmLcoPVflXdlI4Plk6VfbQOlbeiLve3ifrMXvD3uoRXQL1AIOLqAt63Zl1PounZPj8WrNRjxcWjUV8uEX+wvzkitEp+PDOybI3k61qasUtK3ahSfD09x8qqVNWqynqHgYXURckCXjg/MGwGHu2nisxwornrx8Do8InAUSFmvDctaPx92tG+bw9SVccLg9uX7lbcUGhtHqoe3iPi6gLfaKsmDkwoVfHGJ8Rg4cuHoLfrz4kU1XyiA41YeagBMwcFI+ZAxMQGSp/X0aXx4ufvbUXewvrZD92b5UyuFSJwUXUhSn942SZMn3DpHQs35InfI2XTgdMHxCP6yamYXZ2Qpsp/XJyur34vw/2Y8PRSr+dozdK2PVflRhcRF3o6RDhj+n1OlwzPhVPrD0my/F6Ii7Mgg/uOAfpsf7fDHFfYS0e+OAAjlU0+v1cPVVaz+BSI97jIgqgq8f2hUHgva7H5g/3e2g1tbrxh9WHMP+FrYoOLQDIq2oWXQL1AIOLKIASIqyYLrCrRr84/y249XglfLa/DBc+sxkrtuZDEr++uEvFtS2oaXaKLoN8xKFCogBye7w4Vi7uKuRoeSP6J3Tc9aMnnG4vVu0rxrJNuchV4RXMgZJ6zBgYL7oM8gGDiyiA3tlVhNJ6h7Dzf5JTiouGJ3+/qLqn7E43duXXYtupanz8bQnKBP6Zemt/UR2DS2UYXEQBUl7vwF8/Pyq0hrWHKvDK5jzc5mMfxeZWN/YV1mF7bjW25VYjp6gObq8KxgK7Iae4XnQJ5CMGF1GAPL72qCK6Rvzli6MItRhw3YS0Nldebo8XVU1OHKtoxNGyBhTV2pFTVI/DZQ3waCSofoxrudRHJ0lquIVKpH4TH12PioZW0WV8LzUmBClRIQgxGaDX6XCwtB6Vja2qmFQhp3CrEVt+Ncsvi6/JPxhcRAFQXu/ApMc2iC6DOjB/dAqeumaU6DKomzgdnigAcorrRJdAnfhwXwnKuBhZNRhcRAFw6nST6BKoEyNTo5AcGSK6DOomBhdRAFwzLhWxNrPoMqgDN05KF10C+YDBRRQAsWEWPHXNKIRZOJFXaTLjbLhoRLLoMsgHDC6iAJkxMB6f/XwqRvT1bRdl8h+r6cxGn1aTPI2UKTA4q5AowJxuL577zwm8vDkXDpdXdDlB7akFIzF/TF/RZZCPGFxEglQ2OPDPr07i7Z2FcHn4Yxho105IxWPzR4gug3qAwUUkWHm9A6tzSrA6pxQHSxpElxMUzEY9tv96NmI4YUaVGFxECpJ7ugmf5JRhdU4JTp1WX6d1tbh8VB88vXC06DKohzg5g0hBMuPDcPecAfjJjCzRpWha/4Qw0SVQLzC4iBRm0/HTeHTNEdFlECkWF5UQKUSjw4W/fnEUb24vFF2K5jk5GUbVeMVFJJgkSfjiYBnmPvW1akLLoNchXMWLqTceqwRv76sXg4tIsA/2luCnb+5FeYM6dhG2mQ1457ZJ2PPQXLx0w1gMUOH9ov3F9dh0/LToMqiHGFxEgj355THRJfjE5ZGQFGGF2ajHvKFJWL10KqJUuJfVX784hgaHS3QZ1AMMLiLBkiKtokvwidPjxYtfn/r+9yFmA5Ii1PVnAIAjZQ244OnN+CSnVLO7O2sVg4tIsJF9o0SX4DN7q/us30eHqnMhb0ldC+56Zx/mPrUJ7+0ugsvDFlxqwOAiEmxMerToEnx2wfCzu6kb9DpBlcgjt6oZ97+/HzOf2IiHPz2Mf+8uwoHiejhcHtGlUTvUOy2ISCPGqSy4rhidgvOGJp31mNurjSuVkroWLN+S9/3v9TogI86GcenR+PUFgxHNFlGKwOAiEiw50oq4MDOqmpyiS+lSakwI/njZ0DaPF9Voc9t7rwTknm5G7ulmWE0G/OmyYaJLInCokEg4nU6HsSq46jLqdXh24WhEWM+eQdji9KCkTpvB9UN7C2tFl0D/xeAiUoCLR/QRXUKXHrggG6PT2gZsfnVwNAM+WdkEL2cfKgKHCokUYM7gRAxLiVDctiZT+sdiVnYiJmTEYFhKRLvPWbWvJMBVieFweVFUa0d6rE10KUGPwUWkACFmAz66cwpWbM3H39cdR7NT7Gy2senR+NV5gzAxM7bT55XUtWDF1vzAFKUAxyuaGFwKwOAiUgijQY8l0zJx9bhUvL+nGCu35aOg2h7YGvQ6/O6SIbhhUjp0uq6nuD/55TE43dqYUdgdxysaMXdIougygh43kiRSKK9XwsbjlXhm/QnkFNf7/XwpUSF4ZuEojMuI6fK5DpcHf1t7DK/8YOp4MJg3JBEv3ThOdBlBj8FFpHD1dhfG/HmdX9sSXTmmL35/6ZA2Mwbbc7i0Ab/897c4Wt7ot3qUKtRswN6H5sJqMoguJahxqJBIwexON37x7j6/hVZShBV/umwo5v1oQXF7HC4Pnt1wAi99nQt3kM6uszs9+OpoZZvOIRRYDC4iBduRV4Ovjsm//YZOB9wwKR33nzcI4d24ytp6qgoPfngA+QG+56ZE7+wqYnAJxuAiUjC5R/LNRj1G9o3EAxdkY2x61/ey6u0uPLrmCN7dXSRrHWq2+cRpFNfa0Tc6VHQpQYvBRaRgcrWBshj1eP+nk5GdHA6Toeu+A3anG699k49lm06hweHu8vnBRJKAT3LKcMfMLNGlBC0GF5GCFdfIMzTX6vbi5hU7MTAxHEkRViRHWTEoKQJDksOREWuD0aCHxyuhstGBtQfL8Y+vTqGqqVWWc2vRJzmlDC6BGFxECnb3nIFweiS8uOlU10/uQlWTE1VN1W0eN+h1iA41o9bu5IaK3XSishGSJHVrrRvJj70KiRTMoNfhgQuy8c5tk5AW4597Kh6vhKqmVtWHlk53puNHcgB2lHZ5JDhcwbPwWmm4jotIJexON55YewwrtuaDP7Vnm52dgF9fOBj9E8IAAFVNrXhh46mz9taS287fzEZCuP9DktpicBGpzO78Gvzq/f3IrQqOruxdmdo/Dq8uHg+zse0A0ls7CvCbVQdlP2daTCg23jcTepXv/KxWHCokUplxGTFYc/c03D49E8Ygf+PMTgrHC4vGtBtaAHDdhDQkRch/VXTN+FSGlkAMLiIVspoMePDCwfjqvpm4ZKTy9/LyB7NRj+euHd3pAmqdToeMOHnvDVpNelw9tq+sxyTfMLiIVCw1JhTPLhyF3140WHQpAXfv3IEYkBje6XMkSUKLzFvEPHTxECT44SqOuo/BRaRyOp0OS6Zl4k+XDRVdSsD0ibTi5in9unze5wfLZe2sPzs7AddNSJPteNQzDC4ijbjxnIygufK6bXpmh/e1vlPf4sLvVx+S9bx3npvFtVsKwOAi0pAl0zLx+JUjYNDwxIEYmxkLx3d91fP3dcdxulG+7h8J4RaMTo2W7XjUcwwuIo1ZMD4Vry4er9kZh9eMT0WIufP9sE5WNuKN7QWynndyVixnEioEg4tIg2YMjMcv5gwQXYZfzBmc0OnXJUnC7z4+JHsnkImZsbIej3qOwUWkUT+dkYXUmBDRZchKrwOGJEd2+pwDJfXYeqptT8bemtCv621gKDAYXEQaZTTo/bL4VqSMOFuXw4Tb/BBaADT3vVQzBheRhoWYtbUBRHZS5+u2AOBYeaNfzv3kl8exOqfUL8cm3zC4iDTM7dFWB/PkyK6HPv21OHjltnwMSe46OMn/GFxEGlVQ3Yxtuf4ZNhMlopP2Tt/x1329myZnoH8Cg0sJGFxEGrT1ZBWWvL5bc9ufhFu7Hvrs042rMl+ZjXrueKwg2hoAJwpiHq+EzSdO441tBdhwtFJ0OX4REdL1FVefKPmD68JhSYgLs8h+XOoZBheRypXXO/DuriL8e3cRSupaRJfjV9GhXQdXcpT897ium5gu+zGp5xhcRColSRLe3F6AR9YcCZpt5CO7ccUVYTXBYtSj1e3798Ty3/6HP3zt4OQIjM9gqyclYXARqVBlowO/en8/Nh47LbqUgHJ3sxuG3sdGuJlxNvzs3P44b1gSjpU34MoXtn3/tbtm9WdjXYVhcBGpzJeHyvHAhwdQ0+wUXUrANbS4uvW89NhQHO3Geq6UqBDcPXsA5o9JgdFw5mqrvP5/jXlvn56JC4Yl9axY8hsGF5FKFNfa8fCnh7H2UIXoUoSp62ZwjUqN6jS4Ym1m/Ozc/rh+UhosxrM7cbi9XjxwQTZmDIzH4OSIXtVL/sHgIlKB4lo7Lv/nN6hqCr6rrB8qrLZ363m3T8/E5wfLUf+joAs1G7Bkaj/cPiMLYZb23/4uG5XS6zrJvxhcRArX3OrGktd3B31oAcCJyu61c8qMD8PqpVPw+NpjKK5tQXyYBZeMTMbcIYkI1VgbrGDEv0EihduZX9Ot+zXBYE9BHRwuD6ymzhvtAkB6rA3/vG5MAKqiQGPnDCKF6+7wWDCoamrFqn0lossgwRhcRApXwOA6S529exM0SLsYXEQKl1fVJLoERTEZuKYq2DG4iBSsqMaOzSeqRJehKJZu3N8ibWNwESnY8i153e4WEQxsZgMmZMSILoME46xCIgU7XNogugTF6J8QhhcXjUX/hDDRpZBgDC4iBdN6t/fumNgvBgvGpeKiEcndmgZP2sfgIlIot8eL8gaH6DKEGZIcgcevGoFhKZGiSyGFYXARKVR5gwOeIL2/9fPZA3DXrP4wGXgbntpicBEpVHFtcA4T3jEzC7+cO1B0GaRg/DhDpFBfHCwXXULATcqMwX3zBokugxSOwUWkQHV2J/69u0h0GQGXnRQBg54LjKlzDC4iBXp0zRHYnR7RZQRcdzeKpODG4CJSmI+/LcG/dxeLLkOIysbWrp9EQY/BRaQgZfUtePDDA6LLEKawhg2FqWsMLiIFWf1tKZqDcIjwOwnhFtElkAowuIgUZM2BMtElCDOybySeX8SNH6lrXMdFpBBl9S3IKa4XXUZApUSFAAAuHJ6EX84dhBAzWzpR1xhcRApR0RBcExPunTsQd80eILoMUiEOFRIphMMVPPe24sMtDC3qMQYXkUIEU3AlRVhFl0AqxuAiUogGh1t0CQGTyOCiXmBwESnEycom0SUEjMXItx7qOf7rIVKAA8X1eGHjSVmPqeThuIKaZtElkIoxuIgEa3V7cO9738LlkW/vrcevGoGN98/E0nP7w6jAprUFVXZIUnDuNUa9x+AiEuyVzXk4XiHfMOF5QxOxYFwqrCYD7jtvED65a6rihuZ0OoC5RT2lrH/NREHoYIl8i451OrTZz2pwcgSuHNtXtnPIYWJmLPQKvBIkdWBwEQlWL+NWHiNSIjEgMbzN47dO7SfbOeSwRGH1kLowuIgEiw2Tr7Gsw+Vt9/E+kSGynaO3pg2Iw8TMWNFlkIoxuIgEG5QYJtuxTlQ2oqWd7vJNrcpYI6bXAfefN6jrJxJ1gsFFJNhPZmRh2oA4WY7llYD9xXVtHm9WSHDdPXsgRvSNEl0GqRyDi0gwk0GP568fgyHJEbIc752dhW0eU8IV16TMGCyd1V90GaQBDC4iBQi3mvDazeORGNH7+1078mraPFZnl28CSE/E2Mx4ZuFoGDiTkGTA4CJSiMQIK56/fgxMht69uWfFt71nVtno6NUxe+uRy4exPyHJhsFFpCBj02Pwh0uH9uoY7QVfZaPYvb6myHQPjwjgRpJEinP9xHTodTq8/HUucqt87+ln0Lf9PFopcJPKqFATIqwmYecn7eEVF5ECXTshDf+5byZW3TkZk7N8W/OUFW9r81hEiLjPqFEhDC2SF4OLSMFGp0Xj7dsm4ct7pmN2dkK3XjMxM6bNY6NSo2SurPs4IYPkxuAiUoGBieFYvng83rltEkb0jezweUa9DoPbmVYvMrjK6h3sBE+y0kn8F0WkKl6vhEOlDSips+NwaQMOlzXgWEUjLEYDfnPhYJzbwZXZY58fwbJNuQGu9ox9D81FtM0s5NykPQwuoiDh8Uq4feVubDhaGfBzr146hR0zSDYcKiQKEga9Dk8vHIXspLbd4/2tpLYl4Ock7WJwEQWRcKsJby6ZiIEyNvbtjmIGF8mI67iIgkxcmAWf/XwaDpbUY09BLV7enIsKP6/zKq61+/X4FFx4xUUUhEwGPUanRWPJtExsuv9c3DdvoF/P1+AQ3+SXtIPBRRTkrCYDls4agMtG9fHbOZye9je4JOoJBhcRAQDCLP67c1Bnd/rt2BR8GFxEBODM4mV/ya/iPS6SD4OLiAD4dzivullsd3rSFgYXEQEAHC7/BZdBx36FJB8GFxEBAGL92JLJaOBbDcmH/5qICACQFhvqt2OPSYvy27Ep+LBXIREBODPz74JnNqOs3tHrY+l0QGK4FWmxoZiVnYAF41IRwya7JBMGFxF971BpPe56e1+XOy/rdWf2CpvYLwb94mwwGfQw6HWIsZmREhWC5CgrLEZDgKqmYMPgIqKztDg9eH9PEbacrMLWU9Vo/G/Xi8QICzJibZiUGYuFE1KRHBkiuFIKVgwuIuqQ2+NFQY0dSRFW2Py4QJnIFwwuIiJSFc4qJCIiVWFwERGRqjC4iIhIVRhcRESkKgwuIiJSFQYXERGpCoOLiIhUhcFFRESqwuAiIiJVYXAREZGqMLiIiEhVGFxERKQqDC4iIlIVBhcREakKg4uIiFSFwUVERKrC4CIiIlVhcBERkaowuIiISFUYXEREpCoMLiIiUhUGFxERqQqDi4iIVIXBRUREqsLgIiIiVfl/9mniDgGcIdcAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot out the glacier\n",
+    "ax = glacier.plot()\n",
+    "ax.set_axis_off()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21eea74a-84c8-4897-b764-2d486a4e4fb4",
+   "metadata": {},
+   "source": [
+    "Finally, we extract the glacier's geometry to setup the query:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "be9afb78-6eb6-4c39-8c95-f70a8f05ae0f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "glacier_geometry = glacier.geometry.squeeze()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2af10823-24f6-4e02-bfe8-d887c0426280",
+   "metadata": {},
+   "source": [
+    "## Copernicus Open Access Hub"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cd6248f-b119-418f-82e1-7c3cf4d42ca6",
+   "metadata": {},
+   "source": [
+    "We set the credentials to access Copernicus Open Access Hub (register at [this link](https://scihub.copernicus.eu/userguide/SelfRegistration)):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3844ae04-9fd7-42c2-a6fd-b65e818eea8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "username ········\n",
+      "password ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "username = getpass.getpass(\"username\")\n",
+    "password = getpass.getpass(\"password\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3477ebe9-a2e2-42e3-bd14-0c3e2eb20ec2",
+   "metadata": {},
+   "source": [
+    "The API endpoint is available at the following link:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8d56ce51-0e56-4c0a-b2a8-ecab0c873998",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_url = \"https://apihub.copernicus.eu/apihub\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83cb71f4-ee7e-4fec-912a-59c313529d0c",
+   "metadata": {},
+   "source": [
+    "## Imagery search with Sentinelsat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rapid-bristol",
+   "metadata": {},
+   "source": [
+    "We look for the Sentinel-2 scenes that contains the AOI, using [Sentinelsat](https://github.com/sentinelsat/sentinelsat) to query the Copernicus API:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "secure-luxury",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api = sentinelsat.SentinelAPI(\n",
+    "    user=username, \n",
+    "    password=password, \n",
+    "    api_url=api_url,\n",
+    "    show_progressbars=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deadly-cradle",
+   "metadata": {},
+   "source": [
+    "In dhdt we use images processed at **Level-1C** (L1C, top-of-atmosphere reflectance). We use the envelope of the glacier geometry to define the area of interest and consider scenes with an estimated cloud coverage up to 70%:  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "558f0464-2686-4c45-9ef7-3bce562bbccf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "area = glacier_geometry.envelope.wkt\n",
+    "\n",
+    "scenes_l1c = api.query(\n",
+    "    platformname=\"Sentinel-2\",\n",
+    "    producttype=\"S2MSI1C\",\n",
+    "    area=area,\n",
+    "    area_relation=\"Contains\",\n",
+    "    cloudcoverpercentage=(0, 70),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4b9e796-57c2-4e0a-a63d-1929f0ce1e24",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "We then look for the corresponding scenes processed at **Level-2A** (L2A, bottom-of-atmosphere reflectance), which include a scene classification layer that will allow us to mask out clouds. \n",
+    "\n",
+    "First we query for all L2A scenes matching our AOI:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "250f1b9c-2c3b-4ec8-9813-d9e2479593d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scenes_l2a = api.query(\n",
+    "    platformname=\"Sentinel-2\",\n",
+    "    producttype=\"S2MSI2A\",\n",
+    "    area=area,\n",
+    "    area_relation=\"Contains\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3a0b0c1-a084-4892-86e0-2177888da221",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "We then look for the L2A scenes for which we have the corresponding L1C scenes: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "77ee95d5-fa47-40a6-b651-616a01223b88",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# convert search results to GeoDataFrames\n",
+    "gdf_l1c = api.to_geodataframe(scenes_l1c)\n",
+    "gdf_l2a = api.to_geodataframe(scenes_l2a)\n",
+    "\n",
+    "# match scene records\n",
+    "merged = gdf_l1c.merge(\n",
+    "    gdf_l2a.dropna(subset=\"level1cpdiidentifier\"),\n",
+    "    how=\"left\", \n",
+    "    on=\"level1cpdiidentifier\", \n",
+    "    validate=\"1:1\",\n",
+    "    suffixes=[\"_L1C\", \"_L2A\"]\n",
+    ")\n",
+    "\n",
+    "# extract IDs of the L2A scenes matching L1C ones\n",
+    "uuid_l2a = merged[\"uuid_L2A\"].dropna().values\n",
+    "\n",
+    "# get corresponding L2A scenes\n",
+    "scenes_l2a_matched = {uuid: scenes_l2a[uuid] for uuid in uuid_l2a}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6685da00-58dc-4ced-b5da-868bce16c1f1",
+   "metadata": {},
+   "source": [
+    "Print number of selected scenes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "038b78c4-9c18-4d62-9d4a-3525ff023bb4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(486, 321)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(scenes_l1c), len(scenes_l2a_matched)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a9e0b11-314f-43d4-a335-cf6a27b7b86e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Finally we convert the search results to GeoJSON, and write out the corresponding files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "3748c594-f005-431b-8e64-1374789e22eb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def write_to_file(api, scenes, filepath):\n",
+    "    \n",
+    "    # create directory if it does not exists\n",
+    "    dirname = os.path.dirname(filepath)\n",
+    "    os.makedirs(dirname, exist_ok=True)\n",
+    "    \n",
+    "    with open(filepath, \"w\") as f:\n",
+    "        feature_collection = api.to_geojson(scenes)\n",
+    "        geojson.dump(feature_collection, f)   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "8e584916-620d-4105-8e0b-00aa19c1443e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "write_to_file(\n",
+    "    api, \n",
+    "    scenes_l1c, \n",
+    "    \"./data/sentinel-2/sentinel2-l1c.json\"\n",
+    ")\n",
+    "write_to_file(\n",
+    "    api, \n",
+    "    scenes_l2a_matched, \n",
+    "    \"./data/sentinel-2/sentinel2-l2a.json\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44fea288-bb06-4bb3-93b3-9e02506bb4e1",
+   "metadata": {},
+   "source": [
+    "## Imagery download"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92bf395f-2a91-40e3-b457-3f8c2c5da4f0",
+   "metadata": {},
+   "source": [
+    "Sentinelsat also provides tools to download Sentinel data products from the Copernicus Open Access Hub. However, only the most recent images (last 12 months) are kept online, while older images are moved to the [Long Term Archive (LTA)](https://sentinels.copernicus.eu/web/sentinel/-/activation-of-long-term-archive-lta-access-for-copernicus-sentinel-2-and-3). Users can request images to be brought online, with a daily quota."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "772fc754-39a5-40f8-84d4-a45da880d275",
+   "metadata": {},
+   "source": [
+    "Alternative sources of Sentinel-2 imagery are:\n",
+    "* The [Sentinel-2 Open Data collection on AWS](https://registry.opendata.aws/sentinel-2-l2a-cogs/). Data can be discovered via the [Earth Search](https://stacindex.org/catalogs/earth-search#/) SpatioTemporal Asset Catalog (STAC) API. This collection offers free L2A data products converted to cloud-optimized GeoTIFFs. \n",
+    "* The [Sentinel-2 public dataset](https://cloud.google.com/storage/docs/public-datasets/sentinel-2) that is made available as a [bucket](https://console.cloud.google.com/storage/browser/gcp-public-data-sentinel-2) on Google Cloud Storage (GCS). Complete L1C and L2A datasets are available in the original format, including the full set of metadadata files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e76667d-1d83-42b6-bee0-67f2fd211ac1",
+   "metadata": {},
+   "source": [
+    "Here we provide scripts to convert the Sentinelsat search results to STAC, linking the most relevant Sentinel-2 data products to the corresponding files on GCS. We then retrieve these assets.  "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/sentinel-2-imagery/README.md
+++ b/scripts/sentinel-2-imagery/README.md
@@ -40,7 +40,7 @@ Run the same script with the `download` positional argument to retrieve (a subse
 
 ```shell
 # Download Sentinel-2 L1C data (few bands and metadata files)
-python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l1c/catalog.json  download --assets 'blue green red nir product_metadata granule_metadata inspire_metadata datastrip_metadata sensor_metadata_B02 sensor_metadata_B03 sensor_metadata_B04 sensor_metadata_B08'
+python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l1c/catalog.json  download --assets blue green red nir product_metadata granule_metadata inspire_metadata datastrip_metadata sensor_metadata_B02 sensor_metadata_B03 sensor_metadata_B04 sensor_metadata_B08
 # Download Sentinel-2 L2A data (only scene classification layer)
 python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l2a/catalog.json  download --assets scl
 ```

--- a/scripts/sentinel-2-imagery/README.md
+++ b/scripts/sentinel-2-imagery/README.md
@@ -1,0 +1,36 @@
+# Download Sentinel-2 Imagery
+
+## Introduction
+
+In [this notebook](../../docs/tutorials/sentinel-2-imagery.ipynb), we have searched for the Sentinel-2 images that 
+includes a predefined area-of-interest (the Brintnell-Bologna icefield) via the [Copernicus Data Access Hub API]()
+and the [Sentinelsat tool](). Metadata from the scenes that match the search have been saved in GeoJSON format. 
+
+We provide here scripts and instructions to:
+
+* Convert the scenes' metadata from GeoJSON to the SpatioTemporal Asset Catalog (STAC) format, linking the most relevant 
+  Sentinel-2 data products to the corresponding files on [Google Cloud Storage (GCS)](https://cloud.google.com/storage/docs/public-datasets/sentinel-2).
+
+* Download the files from GCS and store these alongside the corresponding scene's metadata. 
+
+## Convert GeoJSON search results to STAC
+
+Run the script `./create_stac_catalog.py` to setup a catalog with links to the GCS assets, e.g.:
+
+```shell
+# Create Sentinel-2 L1C data catalog
+python create_stac_catalog.py ./data/sentinel-2/sentinel2-l1c.json --path ./data/sentinel-2/sentinel2-l1c --description "Sentinel-2 L1C scenes of the Brintnell-Bologna icefield" --template "${year}/${month}/${day}"
+# Create Sentinel-2 L2A data catalog
+python create_stac_catalog.py ./data/sentinel-2/sentinel2-l2a.json --path ./data/sentinel-2/sentinel2-l2a --description "Sentinel-2 L2A scenes of the Brintnell-Bologna icefield" --template "${year}/${month}/${day}"
+```
+
+## Download imagery
+
+Run the script `./download_assets.py` to retrieve (a subset of) the catalogs' assets:
+
+```shell
+# Download Sentinel-2 L1C data (few bands and metadata files)
+python download_assets.py --assets blue green red nir product_metadata granule_metadata inspire_metadata datastrip_metadata sensor-metadata-B02 sensor-metadata-B03 sensor-metadata-B04 sensor-metadata-B08
+# Download Sentinel-2 L2A data (only scene classification layer)
+python download_assets.py --assets scl
+```

--- a/scripts/sentinel-2-imagery/README.md
+++ b/scripts/sentinel-2-imagery/README.md
@@ -15,22 +15,23 @@ We provide here scripts and instructions to:
 
 ## Convert GeoJSON search results to STAC
 
-Run the script `./create_stac_catalog.py` to setup a catalog with links to the GCS assets, e.g.:
+Run the script [sentinel-2-STAC.py](./sentinel-2-STAC.py) with the `create` positional argument to create a catalog with 
+links to the GCS assets, e.g.:
 
 ```shell
 # Create Sentinel-2 L1C data catalog
-python create_stac_catalog.py ./data/sentinel-2/sentinel2-l1c.json --path ./data/sentinel-2/sentinel2-l1c --description "Sentinel-2 L1C scenes of the Brintnell-Bologna icefield" --template "${year}/${month}/${day}"
+python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l1c create --from-geojson ./data/sentinel-2/sentinel2-l1c.json --description 'Sentinel-2 L1C scenes of the Brintnell-Bologna icefield' --template '${year}/${month}/${day}'
 # Create Sentinel-2 L2A data catalog
-python create_stac_catalog.py ./data/sentinel-2/sentinel2-l2a.json --path ./data/sentinel-2/sentinel2-l2a --description "Sentinel-2 L2A scenes of the Brintnell-Bologna icefield" --template "${year}/${month}/${day}"
+python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l2a create --from-geojson ./data/sentinel-2/sentinel2-l2a.json --description 'Sentinel-2 L2A scenes of the Brintnell-Bologna icefield' --template '${year}/${month}/${day}'
 ```
 
 ## Download imagery
 
-Run the script `./download_assets.py` to retrieve (a subset of) the catalogs' assets:
+Run the same script with the `download` positional argument to retrieve (a subset of) the catalogs' assets:
 
 ```shell
 # Download Sentinel-2 L1C data (few bands and metadata files)
-python download_assets.py --assets blue green red nir product_metadata granule_metadata inspire_metadata datastrip_metadata sensor-metadata-B02 sensor-metadata-B03 sensor-metadata-B04 sensor-metadata-B08
+python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l1c/catalog.json  download --assets blue green red nir product_metadata granule_metadata inspire_metadata datastrip_metadata sensor_metadata_B02 sensor_metadata_B03 sensor_metadata_B04 sensor_metadata_B08
 # Download Sentinel-2 L2A data (only scene classification layer)
-python download_assets.py --assets scl
+python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l2a/catalog.json  download --assets scl
 ```

--- a/scripts/sentinel-2-imagery/README.md
+++ b/scripts/sentinel-2-imagery/README.md
@@ -40,7 +40,7 @@ Run the same script with the `download` positional argument to retrieve (a subse
 
 ```shell
 # Download Sentinel-2 L1C data (few bands and metadata files)
-python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l1c/catalog.json  download --assets blue green red nir product_metadata granule_metadata inspire_metadata datastrip_metadata sensor_metadata_B02 sensor_metadata_B03 sensor_metadata_B04 sensor_metadata_B08
+python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l1c/catalog.json  download --assets 'blue green red nir product_metadata granule_metadata inspire_metadata datastrip_metadata sensor_metadata_B02 sensor_metadata_B03 sensor_metadata_B04 sensor_metadata_B08'
 # Download Sentinel-2 L2A data (only scene classification layer)
 python sentinel-2-STAC.py --catalog-path ./data/sentinel-2/sentinel2-l2a/catalog.json  download --assets scl
 ```

--- a/scripts/sentinel-2-imagery/README.md
+++ b/scripts/sentinel-2-imagery/README.md
@@ -3,20 +3,29 @@
 ## Introduction
 
 In [this notebook](../../docs/tutorials/sentinel-2-imagery.ipynb), we have searched for the Sentinel-2 images that 
-includes a predefined area-of-interest (the Brintnell-Bologna icefield) via the [Copernicus Data Access Hub API]()
-and the [Sentinelsat tool](). Metadata from the scenes that match the search have been saved in GeoJSON format. 
+include a predefined area-of-interest (the Brintnell-Bologna icefield) via the [Copernicus Data Access Hub API](https://scihub.copernicus.eu/)
+and the [Sentinelsat tool](https://github.com/sentinelsat/sentinelsat). Metadata from the scenes that match the search 
+have been saved in GeoJSON format. 
 
 We provide here scripts and instructions to:
 
 * Convert the scenes' metadata from GeoJSON to the SpatioTemporal Asset Catalog (STAC) format, linking the most relevant 
   Sentinel-2 data products to the corresponding files on [Google Cloud Storage (GCS)](https://cloud.google.com/storage/docs/public-datasets/sentinel-2).
 
-* Download the files from GCS and store these alongside the corresponding scene's metadata. 
+* Download the data files from GCS and store these alongside the corresponding scene's metadata. 
+
+## Requirements
+
+The following required libraries can be installed with `pip`:
+
+```shell
+pip install geopandas pystac stactools stactools-sentinel2
+```
 
 ## Convert GeoJSON search results to STAC
 
-Run the script [sentinel-2-STAC.py](./sentinel-2-STAC.py) with the `create` positional argument to create a catalog with 
-links to the GCS assets, e.g.:
+Run the Python script [sentinel-2-STAC.py](./sentinel-2-STAC.py) with the `create` positional argument to create a 
+catalog with links to the GCS assets, e.g.:
 
 ```shell
 # Create Sentinel-2 L1C data catalog

--- a/scripts/sentinel-2-imagery/create_stac_catalog.py
+++ b/scripts/sentinel-2-imagery/create_stac_catalog.py
@@ -1,0 +1,166 @@
+"""
+Generate a SpatioTemporal Asset Catalog (STAC) from the Sentinel-2 metadata
+returned by the Copernicus Open Access Hub API. Assets are linked to files on
+the Sentinel-2 public dataset on Google Cloud Storage (GCS):
+
+https://cloud.google.com/storage/docs/public-datasets/sentinel-2
+
+"""
+import argparse
+import os
+
+from typing import Dict, Tuple
+
+import geopandas as gpd
+import pystac
+
+from stactools.core.io.xml import XmlElement
+from stactools.sentinel2.stac import create_item
+from stactools.sentinel2.constants import GRANULE_METADATA_ASSET_KEY
+
+
+GCS_ROOT_URL = "https://storage.googleapis.com"
+SENTINEL2_BUCKET = "gcp-public-data-sentinel-2"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "geojson", type=str, help="Path to the Sentinel-2 metadata file"
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        help="Path to the STAC catalog",
+        default="./catalog",
+    )
+    parser.add_argument(
+        "--description",
+        type=str,
+        help="Brief catalog description",
+        default="My STAC catalog",
+    )
+    parser.add_argument(
+        "--template", type=str, help="Catalog structure",
+    )
+    return parser.parse_args()
+
+
+def _get_granule_href(safe_filename: str) -> str:
+    """ Construct HREF with full GCS URL from the SAFE file name. """
+    bucket_url = f"{GCS_ROOT_URL}/{SENTINEL2_BUCKET}"
+    root_url = (
+        bucket_url if "_MSIL1C_" in safe_filename else f"{bucket_url}/L2"
+    )
+    tile_id = safe_filename[39:44]
+    return (
+        f"{root_url}/"
+        f"tiles/{tile_id[:2]}/{tile_id[2]}/{tile_id[3:]}/"
+        f"{safe_filename}"
+    )
+
+
+def _get_sensor_array_key_asset_pair(href: str) -> Tuple[str, pystac.Asset]:
+    """
+    Create the asset corresponding to a sensor array data file from it HREF.
+
+    Notes
+    -----
+    The GML format was employed for older Sentinel-2 scenes, while JPEG2000 is
+    used for the most recent ones.
+    """
+    stem, ext = os.path.splitext(href)
+    band_key = stem.split("_")[-1]
+    media_type = (
+        pystac.MediaType.XML if ext == ".gml" else pystac.MediaType.JPEG2000
+    )
+    asset = pystac.Asset(href=href, media_type=media_type, roles=["metadata"])
+    return f"sensor-metadata-{band_key}", asset
+
+
+def _create_sensor_array_assets(
+        granule_href: str, granule_metadata_href: str
+) -> Dict[str, pystac.Asset]:
+    """
+    Set up an asset dictionary including the sensor array data. Extract names
+    and relative paths of the data files from the granule metadata file.
+    """
+    sensor_array_assets = {}
+    root = XmlElement.from_file(granule_metadata_href)
+    elements = (
+        root.findall("n1:Quality_Indicators_Info/Pixel_Level_QI/MASK_FILENAME")
+    )
+    for element in elements:
+        if element.get_attr("type") == "MSK_DETFOO":
+            asset_href = os.path.join(granule_href, element.text)
+            key, asset = _get_sensor_array_key_asset_pair(asset_href)
+            sensor_array_assets[key] = asset
+    return sensor_array_assets
+
+
+def _create_item(safe_filename: str) -> pystac.Item:
+    """ Create a STAC item corresponding to a SAFE filename. """
+    granule_href = _get_granule_href(safe_filename)
+    item = create_item(granule_href)
+    granule_metadata_href = item.assets[GRANULE_METADATA_ASSET_KEY].href
+    sensor_array_assets = _create_sensor_array_assets(
+        granule_href, granule_metadata_href
+    )
+    item.assets.update(sensor_array_assets)
+    return item
+
+
+def create_stac_catalog(
+        geojson_path: str, catalog_path: str, catalog_description: str,
+        template: str = None
+) -> None:
+    """
+    Create a STAC catalog from the scenes' metadata retrieved from the
+    Copernicus Open Access Hub API and saved locally in GeoJSON format. Assets
+    are linked to the corresponding files on the Sentinel-2 public dataset on
+    Google Cloud Storage.
+
+    Parameters
+    ----------
+    geojson_path: str
+        path to the GeoJSON file containing the scenes' metadata
+    catalog_path: str
+        path where to save the STAC catalog
+    catalog_description: str
+        short description of the catalog
+    template: str, optional
+        if provided, organize items in a nested catalog structure according to
+        this template
+    Returns
+    -------
+    pystac.Catalog : list of items corresponding to the Sentinel-2 scenes.
+    """
+
+    _, catalog_id = os.path.split(catalog_path)
+    catalog = pystac.Catalog(id=catalog_id, description=catalog_description)
+
+    scenes_df = gpd.read_file(geojson_path)
+    items = (_create_item(scene.filename) for _, scene in scenes_df.iterrows())
+    catalog.add_items(items)
+
+    if template is not None:
+        catalog.generate_subcatalogs(template)
+
+    catalog.normalize_and_save(
+        catalog_path,
+        catalog_type=pystac.CatalogType.SELF_CONTAINED
+    )
+
+
+def main():
+    args = parse_args()
+    create_stac_catalog(
+        geojson_path=args.geojson,
+        catalog_path=args.path,
+        catalog_description=args.description,
+        template=args.template,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sentinel-2-imagery/sentinel-2-STAC.py
+++ b/scripts/sentinel-2-imagery/sentinel-2-STAC.py
@@ -146,7 +146,7 @@ def create_stac_catalog(args: argparse.Namespace) -> None:
     catalog = pystac.Catalog(id=catalog_id, description=catalog_description)
 
     scenes_df = gpd.read_file(geojson_path)
-    items = (_create_item(scene.filename) for _, scene in scenes_df.loc[:2].iterrows())
+    items = (_create_item(scene.filename) for _, scene in scenes_df.iterrows())
     catalog.add_items(items)
 
     if template is not None:

--- a/scripts/sentinel-2-imagery/sentinel-2-STAC.py
+++ b/scripts/sentinel-2-imagery/sentinel-2-STAC.py
@@ -1,11 +1,15 @@
 """
 Generate a SpatioTemporal Asset Catalog (STAC) from the Sentinel-2 metadata
 returned by the Copernicus Open Access Hub API. Assets are linked to files on
-the Sentinel-2 public dataset on Google Cloud Storage (GCS):
+the Sentinel-2 public dataset on Google Cloud Storage (GCS)[1]. Optionally
+download (a subset of) the assets and store these alongside the respective
+scenes' metadata.
 
 https://cloud.google.com/storage/docs/public-datasets/sentinel-2
 
 """
+__version__ = "0.1"
+
 import argparse
 import os
 
@@ -14,6 +18,8 @@ from typing import Dict, Tuple
 import geopandas as gpd
 import pystac
 
+from pystac.utils import make_relative_href
+from stactools.core.copy import move_asset_file_to_item
 from stactools.core.io.xml import XmlElement
 from stactools.sentinel2.stac import create_item
 from stactools.sentinel2.constants import GRANULE_METADATA_ASSET_KEY
@@ -23,27 +29,41 @@ GCS_ROOT_URL = "https://storage.googleapis.com"
 SENTINEL2_BUCKET = "gcp-public-data-sentinel-2"
 
 
-def parse_args():
+def parse_args(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "geojson", type=str, help="Path to the Sentinel-2 metadata file"
-    )
-    parser.add_argument(
-        "--path",
+        "--catalog-path",
         type=str,
         help="Path to the STAC catalog",
-        default="./catalog",
+        required=True,
     )
-    parser.add_argument(
+    subparsers = parser.add_subparsers(required=True)
+
+    create_parser = subparsers.add_parser("create")
+    create_parser.add_argument(
+        "--from-geojson",
+        type=str,
+        help="Path to the Sentinel-2 metadata file",
+        required=True,
+    )
+    create_parser.add_argument(
         "--description",
         type=str,
         help="Brief catalog description",
         default="My STAC catalog",
+        required=True,
     )
-    parser.add_argument(
+    create_parser.add_argument(
         "--template", type=str, help="Catalog structure",
     )
-    return parser.parse_args()
+    create_parser.set_defaults(run=create_stac_catalog)
+
+    download_parser = subparsers.add_parser("download")
+    download_parser.add_argument(
+        "--assets", nargs='*', help="List of asset keys"
+    )
+    download_parser.set_defaults(run=download_assets)
+    return parser.parse_args(args)
 
 
 def _get_granule_href(safe_filename: str) -> str:
@@ -75,7 +95,7 @@ def _get_sensor_array_key_asset_pair(href: str) -> Tuple[str, pystac.Asset]:
         pystac.MediaType.XML if ext == ".gml" else pystac.MediaType.JPEG2000
     )
     asset = pystac.Asset(href=href, media_type=media_type, roles=["metadata"])
-    return f"sensor-metadata-{band_key}", asset
+    return f"sensor_metadata_{band_key}", asset
 
 
 def _create_sensor_array_assets(
@@ -110,37 +130,23 @@ def _create_item(safe_filename: str) -> pystac.Item:
     return item
 
 
-def create_stac_catalog(
-        geojson_path: str, catalog_path: str, catalog_description: str,
-        template: str = None
-) -> None:
+def create_stac_catalog(args: argparse.Namespace) -> None:
     """
     Create a STAC catalog from the scenes' metadata retrieved from the
     Copernicus Open Access Hub API and saved locally in GeoJSON format. Assets
     are linked to the corresponding files on the Sentinel-2 public dataset on
     Google Cloud Storage.
-
-    Parameters
-    ----------
-    geojson_path: str
-        path to the GeoJSON file containing the scenes' metadata
-    catalog_path: str
-        path where to save the STAC catalog
-    catalog_description: str
-        short description of the catalog
-    template: str, optional
-        if provided, organize items in a nested catalog structure according to
-        this template
-    Returns
-    -------
-    pystac.Catalog : list of items corresponding to the Sentinel-2 scenes.
     """
+    catalog_path = args.catalog_path
+    geojson_path = args.from_geojson
+    catalog_description = args.description
+    template = args.template
 
     _, catalog_id = os.path.split(catalog_path)
     catalog = pystac.Catalog(id=catalog_id, description=catalog_description)
 
     scenes_df = gpd.read_file(geojson_path)
-    items = (_create_item(scene.filename) for _, scene in scenes_df.iterrows())
+    items = (_create_item(scene.filename) for _, scene in scenes_df.loc[:2].iterrows())
     catalog.add_items(items)
 
     if template is not None:
@@ -152,14 +158,36 @@ def create_stac_catalog(
     )
 
 
-def main():
-    args = parse_args()
-    create_stac_catalog(
-        geojson_path=args.geojson,
-        catalog_path=args.path,
-        catalog_description=args.description,
-        template=args.template,
-    )
+def download_assets(args: argparse.Namespace) -> None:
+    """
+    Download (a subsection of) the catalog assets and store these alongside the
+    corresponding items.
+    """
+    catalog_path = args.catalog_path
+    asset_keys = args.assets
+
+    path = catalog_path \
+        if catalog_path.endswith("catalog.json") \
+        else f"{catalog_path}/catalog.json"
+    catalog = pystac.Catalog.from_file(path)
+
+    for item in catalog.get_all_items():
+        keys = asset_keys if asset_keys is not None else item.assets.keys()
+        for key in keys:
+            asset = item.assets[key]
+            asset_abs_href = asset.get_absolute_href()
+            asset_href = move_asset_file_to_item(
+                item,
+                asset_abs_href,
+                copy=True,
+            )
+            asset.href = make_relative_href(asset_href, item.get_self_href())
+        item.save_object()
+
+
+def main(args: list = None) -> None:
+    args_parsed = parse_args(args)
+    args_parsed.run(args_parsed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduces a tutorial notebook on how to search for Sentinel-2 optical images on Copernicus Open Access Hub and a script to retrieve data as a STAC catalog.