### PR TITLE
Fix and simplify generation of generic Sentinel-2 raster

### DIFF
--- a/dhdt/generic/handler_sentinel2.py
+++ b/dhdt/generic/handler_sentinel2.py
@@ -251,7 +251,7 @@ def get_generic_s2_raster(tile_code, spac=10, mgrs_tiling_file=None):
     """
     assert spac in (10, 20, 60,), 'please provide correct pixel resolution'
 
-    tile_code = normalize_mgrs_code(tile_code)
+    tile_code = check_mgrs_code(tile_code)
     geom = get_geom_for_tile_code(tile_code, geom_path=mgrs_tiling_file)
 
     # specify coordinate systems

--- a/dhdt/generic/handler_sentinel2.py
+++ b/dhdt/generic/handler_sentinel2.py
@@ -2,7 +2,6 @@ import os
 
 from osgeo import osr
 
-import affine
 import numpy as np
 import pandas as pd
 import pyproj
@@ -233,10 +232,8 @@ def get_generic_s2_raster(tile_code, spac=10, mgrs_tiling_file=None):
 
     Returns
     -------
-    affine.Affine
-        georeference transform of an image
     tuple
-        shape of the image: (ny, nx)
+        georeference transform of an image, including shape
     pyproj.crs.crs.CRS
         coordinate reference system (CRS)
 
@@ -273,9 +270,10 @@ def get_generic_s2_raster(tile_code, spac=10, mgrs_tiling_file=None):
     x, y = np.round(np.array(xx)/spac)*spac, np.round(np.array(yy)/spac)*spac
 
     spac = float(spac)
-    transform = affine.Affine(spac, 0., np.min(x), 0., -spac, np.max(y))
-    shape = (int(np.round(np.ptp(y)/spac)), int(np.round(np.ptp(x)/spac)))
-    return transform, shape, crs_utm
+    nx = int(np.round(np.ptp(x)/spac))
+    ny = int(np.round(np.ptp(y)/spac))
+    geoTransform = (np.min(x), +spac, 0., np.max(y), 0., -spac, ny, nx)
+    return geoTransform, crs_utm
 
 def get_s2_image_locations(fname,s2_df):
     """

--- a/dhdt/generic/handler_sentinel2.py
+++ b/dhdt/generic/handler_sentinel2.py
@@ -267,7 +267,9 @@ def get_generic_s2_raster(tile_code, spac=10, mgrs_tiling_file=None):
         crs_from=crs, crs_to=crs_utm, always_xy=True
     )
     geom_utm = shapely.ops.transform(transformer.transform, geom)
-    xx, yy = geom_utm.exterior.coords.xy
+    # geom can still be a multipolygon for tiles crossing the antimeridian
+    geom_merged = shapely.unary_union(geom_utm, grid_size=0.001)
+    xx, yy = geom_merged.exterior.coords.xy
     x, y = np.round(np.array(xx)/spac)*spac, np.round(np.array(yy)/spac)*spac
 
     spac = float(spac)

--- a/dhdt/generic/handler_sentinel2.py
+++ b/dhdt/generic/handler_sentinel2.py
@@ -268,7 +268,7 @@ def get_generic_s2_raster(tile_code, spac=10, mgrs_tiling_file=None):
     )
     geom_utm = shapely.ops.transform(transformer.transform, geom)
     xx, yy = geom_utm.exterior.coords.xy
-    x, y = np.round(xx/spac)*spac, np.round(yy/spac)*spac
+    x, y = np.round(np.array(xx)/spac)*spac, np.round(np.array(yy)/spac)*spac
 
     spac = float(spac)
     transform = affine.Affine(spac, 0., np.min(x), 0., -spac, np.max(y))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ scipy
 Pillow
 shapely
 statsmodels
+affine
+pyproj

--- a/tests/auxiliary/test_handler_randolph.py
+++ b/tests/auxiliary/test_handler_randolph.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 
-import affine
 import geopandas as gpd
 import numpy as np
 import pyproj
@@ -25,18 +24,17 @@ def _set_up_data_for_rgi_raster():
     crs = pyproj.CRS.from_epsg(EPSG_CODE)
 
     gdal_transform = (461000, 20., 0.,  6624200., 0., -20.)
-    transform = affine.Affine.from_gdal(*gdal_transform)
-    return shapes, crs, transform, RASTER_SHAPE
+    geoTransform = (*gdal_transform, *RASTER_SHAPE)
+    return shapes, crs, geoTransform
 
 
 def test_create_rgi_raster_set_up_correct_raster_file():
-    shapes, crs, transform, shape = _set_up_data_for_rgi_raster()
+    shapes, crs, geoTransform = _set_up_data_for_rgi_raster()
     with tempfile.TemporaryDirectory() as tmpdir:
         raster_path = os.path.join(tmpdir, "tmp.tif")
         create_rgi_raster(
             rgi_shapes=shapes,
-            transform=transform,
-            shape=shape,
+            geoTransform=geoTransform,
             crs=crs,
             raster_path=raster_path,
         )

--- a/tests/generic/test_handler_sentinel2.py
+++ b/tests/generic/test_handler_sentinel2.py
@@ -1,0 +1,17 @@
+from dhdt.generic.handler_sentinel2 import get_generic_s2_raster
+
+TESTDATA_DIR = 'testdata/'
+
+# The MGRS file
+MGRS_INDEX_FILE = f'{TESTDATA_DIR}/MGRS/mgrs_tiles_tiny.geojson'
+
+
+def test_get_generic_s2_raster_returns_correct_crs():
+    tile_codes = ['07MHV', '01CCV', '41UQV', '60MXA']
+    utm_zones = ['7S', '1S', '41N', '60S']
+    for tile_code, utm_zone in zip(tile_codes, utm_zones):
+        _, crs = get_generic_s2_raster(
+            tile_code=tile_code,
+            mgrs_tiling_file=MGRS_INDEX_FILE
+        )
+        assert crs.utm_zone == utm_zone


### PR DESCRIPTION
Fixing the function that generates metadata for the Sentinel-2 tiles. 

I have dropped OGR/OSR/GDAL in favour of shapely/pyproj/affine that are better integrated with GeoPandas (they are actually GeoPandas dependencies, so even though they are explicitly added in the requirements, it does not add additional packages to the stack)