### PR TITLE
Fix MGRS geometries for tiles crossing antimeridian line

### DIFF
--- a/dhdt/auxilary/handler_copernicusdem.py
+++ b/dhdt/auxilary/handler_copernicusdem.py
@@ -26,7 +26,7 @@ from dhdt.generic.mapping_io import read_geo_info
 from dhdt.generic.mapping_tools import get_bbox, get_shape_extent
 from dhdt.generic.handler_sentinel2 import get_crs_from_mgrs_tile
 from dhdt.generic.unit_check import check_mgrs_code
-from dhdt.auxilary.handler_mgrs import get_mgrs_geometry
+from dhdt.auxilary.handler_mgrs import get_geom_for_tile_code
 
 
 def get_itersecting_DEM_tile_names(index, geometry):
@@ -363,8 +363,9 @@ def get_copDEM_s2_tile_intersect_list(mgrs_tile, mgrs_path=None,
     - DTED : digital terrain elevation data
     """
     mgrs_tile = check_mgrs_code(mgrs_tile)
-    s2_geom = get_mgrs_geometry(mgrs_tile, mgrs_dir=mgrs_path,
-                                mgrs_file=mgrs_file)
+    s2_geom = get_geom_for_tile_code(
+        mgrs_tile, geom_path=os.path.join(mgrs_path, mgrs_file)
+    )
 
     urls, tars = get_copDEM_geometry_intersect_list(s2_geom,
         sso=sso, pw=pw, cop_path=cop_path, cop_file=cop_file, map_file=map_file)

--- a/dhdt/auxilary/handler_mgrs.py
+++ b/dhdt/auxilary/handler_mgrs.py
@@ -16,7 +16,7 @@ import geopandas as gpd
 import numpy as np
 from shapely import wkt
 
-from shapely.geometry import Polygon
+from shapely.geometry import Polygon, MultiPolygon
 from fiona.drvsupport import supported_drivers
 
 from dhdt.generic.handler_www import get_file_from_www
@@ -129,20 +129,18 @@ def get_geom_for_tile_code(tile_code, geom_path=None):
 
     tile_code = check_mgrs_code(tile_code)
 
-    # Derive a search box from the tile code
-    search_box = _mgrs_to_searchbox(tile_code)
+    # Derive a search geometry from the tile code
+    search_geom = _mgrs_to_search_geometry(tile_code)
 
-    # Load tiles intersects the search box
-    mgrs_tiles = gpd.read_file(geom_path, bbox=search_box)
+    # Load tiles
+    mgrs_tiles = gpd.read_file(geom_path, mask=search_geom)
 
     geom = mgrs_tiles[mgrs_tiles['Name'] == tile_code]["geometry"]
 
     if len(geom) == 0:
         raise ValueError('MGRS tile code does not seem to exist')
-    elif len(geom) > 1:
-        raise ValueError('Multiple tiles matching the tile code')
 
-    return geom.squeeze()
+    return geom.unary_union
 
 def get_bbox_from_tile_code(tile_code, geom_path=None):
     """
@@ -212,10 +210,11 @@ def get_tile_codes_from_geom(geom, geom_path=None):
 
     return codes
 
-def _mgrs_to_searchbox(tile_code):
+def _mgrs_to_search_geometry(tile_code):
     """
-    Get a search box from the tile code. The search box is a 6-deg longitude
-    stripe
+    Get a geometry from the tile code. The search geometry is a 6-deg longitude
+    stripe, augmented with the stripe across the antimeridian for the tiles
+    that are crossing this line.
 
     Parameters
     ----------
@@ -224,13 +223,21 @@ def _mgrs_to_searchbox(tile_code):
 
     Returns
     -------
-    tuple
-        bounding box of the search area in (minx, miny, maxx, maxy)
+    shapely.Geometry
+        geometry to restrict the search area
     """
     nr_lon = int(tile_code[0:2])  # first two letters indicates longitude range
     min_lon = -180.+(nr_lon-1)*6.
     max_lon = -180.+nr_lon*6.
-    return min_lon, -90.0, max_lon, 90.0
+    geom = Polygon.from_bounds(min_lon, -90.0, max_lon, 90.0)
+    extra = None
+    if nr_lon == 1:
+        extra = Polygon.from_bounds(174, -90.0, 180, 90.0)
+    elif nr_lon == 60:
+        extra = Polygon.from_bounds(-180, -90.0, -174, 90.0)
+    if extra is not None:
+        geom = MultiPolygon(polygons=[geom, extra])
+    return geom
 
 def get_mgrs_geometry(mgrs_tile, mgrs_dir=None,
                       mgrs_file='sentinel2_tiles_world.geojson'):

--- a/dhdt/auxilary/handler_mgrs.py
+++ b/dhdt/auxilary/handler_mgrs.py
@@ -238,16 +238,3 @@ def _mgrs_to_search_geometry(tile_code):
     if extra is not None:
         geom = MultiPolygon(polygons=[geom, extra])
     return geom
-
-def get_mgrs_geometry(mgrs_tile, mgrs_dir=None,
-                      mgrs_file='sentinel2_tiles_world.geojson'):
-    mgrs_dir = MGRS_TILING_DIR_DEFAULT if mgrs_dir is None else mgrs_dir
-
-    file_path = os.path.join(mgrs_dir, mgrs_file)
-    assert os.path.isfile(file_path), 'make sure file exist'
-
-    mgrs_df = gpd.read_file(file_path) # get dataframe of Sentinel-2 tiles
-    mgrs_df = mgrs_df[mgrs_df['Name'].isin([mgrs_tile])]
-    assert (mgrs_df is not None), ('tile not present in shapefile')
-
-    return mgrs_df['geometry'].item()


### PR DESCRIPTION
There was an issue with the current MGRS Implementation, which would not consider the area of the tiles on the other side of the antemeridian for tiles with UTM code 1 or 60.  This should be now fixed.

The function that calculates the bbox for a given MGRS tile code still has a "weird" behaviour, giving (-180, min_lat, 180, max_lat) as bbox for the tiles in UTM zones 1 and 60. This is a bit of a corner case, maybe we can open an issue and address this later?

A question @dicaearchus: I have seen you have added the function `get_mgrs_geometry` ([here](https://github.com/GO-Eratosthenes/dhdt/blob/3b9ebd9a77883982a6b03a88efd51c19985634f2/dhdt/auxilary/handler_mgrs.py#L235)), but this is the same functionality of `get_geom_for_tile_code`([here](https://github.com/GO-Eratosthenes/dhdt/blob/3b9ebd9a77883982a6b03a88efd51c19985634f2/dhdt/auxilary/handler_mgrs.py#L108)) - with the latter being a bit more efficient because it loads only the portion of the GeoJSON file that is actually needed. Can I drop `get_mgrs_geometry `? 